### PR TITLE
docs: remove non-existing API from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@ $ npm install @mswjs/source -D
 $ yarn add @mswjs/source -D
 ```
 
+## Choose the source
+
+Choose one, or multiple sources to generate request handlers from:
+
+- [Browser traffic (HAR file)](#browser-traffic-har-file)
+
 ## Browser traffic (HAR file)
 
-You can use the `fromTraffic` function to generate request handlers from an [HTTP Archive (HAR)](<https://en.wikipedia.org/wiki/HAR_(file_format)>):
+Use the `fromTraffic` function to generate request handlers from an [HTTP Archive (HAR)](<https://en.wikipedia.org/wiki/HAR_(file_format)>):
 
 ```js
 import { fromTraffic } from '@mswjs/source'
@@ -23,7 +29,7 @@ export const handlers = fromTraffic(har)
 
 > Note that `*.har` files are written in JSON so you don't have to process their imports in any way.
 
-### How to export a HAR file
+### Exporting an HAR file
 
 You can generate and export an HAR file using your browser. Please see the detailed instructions on how to do that below.
 
@@ -61,7 +67,46 @@ You can generate and export an HAR file using your browser. Please see the detai
   </ol>
 </details>
 
-### Response order sensitivity
+### Features
+
+- [Response timing](#response-timing)
+- [Response order sensitivity](#response-order-sensitivity)
+- [Customizing generated handlers](#customizing-generated-handlers)
+
+#### Response timing
+
+Generated handlers respect the response timing from the respective HAR entries.
+
+Take a look at this archive describing a request/response entry:
+
+```json
+{
+  "log": {
+    "entries": [
+      {
+        "request": {
+          "method": "GET",
+          "url": "https://example.com/settings"
+        },
+        "response": {
+          "content": "hello world"
+        },
+        "time": 554
+      }
+    ]
+  }
+}
+```
+
+The request handler for `GET https://example.com/settings` will have a _delayed_ response using the `log.entries[i].time` (ms) as the delay duration. Roughly, it can be represented as follows:
+
+```js
+rest.get('https://example.com/settings', (req, res, ctx) => {
+  return res(ctx.text('hello world'), ctx.delay(554))
+})
+```
+
+#### Response order sensitivity
 
 If the same request has multiple responses in the archive, those responses will be used sequentially in the handlers.
 
@@ -116,7 +161,7 @@ fetch('https://example.com/user').then((res) => res.text())
 
 Note that any subsequent request to the same endpoint **will receive the _latest_ response** it has in the HAR. In the example above, any subsequent request will receive a mocked `404` response.
 
-### Customizing generated handlers
+#### Customizing generated handlers
 
 The `fromTraffic` function accepts an optional second argument, which is a function that maps each network entry in the archive. You can use this function to modify or skip certain entries when generating request handlers.
 


### PR DESCRIPTION
- No point in listing an API that doesn't exist;
- Rephrase certain sections;
- Add the top description for the README. 