### PR TITLE
feat(fromOpenApi): support the "uri" string format

### DIFF
--- a/src/fromOpenApi/fromOpenApi.ts
+++ b/src/fromOpenApi/fromOpenApi.ts
@@ -219,6 +219,10 @@ export function evolveJsonSchema(
         case 'date-time': {
           return datatype.datetime(schema.maximum).toISOString()
         }
+
+        case 'uri': {
+          return internet.url()
+        }
       }
 
       // Use a random value from the specified enums list.

--- a/test/oas/evolve-json-schema.test.ts
+++ b/test/oas/evolve-json-schema.test.ts
@@ -75,6 +75,14 @@ describe('string', () => {
     })
     expect(value).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+?Z$/)
   })
+
+  it('supports the "uri" format', () => {
+    const value = evolveJsonSchema({
+      type: 'string',
+      format: 'uri',
+    })
+    expect(value).toMatch(/^https?:\/\/\w+\.\w+?$/)
+  })
 })
 
 describe('boolean', () => {


### PR DESCRIPTION
Adds support for the `uri` string format in JSON Schema. 