### PR TITLE
docs: add dual license draft

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,56 @@
+# Source License
+
+Depending on the type of your legal entity, you are granted permission to use Source for your project. Individuals and small companies are allowed to use Source for free, including for commercial use, while a company license is required for for-profit organizations of a certain size. Please refer to the actual licenses below for more details.
+
+- [Free license](#free-license)
+- [Company license](#company-license)
+
+## Free license
+
+### Eligibility
+
+You are allowed to use Source for free for commercial and non-commercial projects if you are:
+
+- An individual;
+- A non-profit or non-for-profit organization;
+- A for-profit organization with up to 3 workers.
+
+### Allowed use cases
+
+Permission is hereby granted, free of charge, to any person or company eligible for the "Free license" to use the software non-commercially or commercially and modify the software for the purpose of contributing bug fixes or improvements back to Source.
+
+### Prohibited use cases
+
+Is it prohibited to copy, modify, distribute, or redistribute the software for the purpose of selling, renting, licensing, relicensing, or sublicensing own derivate of Source.
+
+### Warranty notice
+
+The software is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and non-infringement. In no event shall the author or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.
+
+### Support
+
+Support is provided on a best-we-can-do basis via GitHub Issues.
+
+## Company license
+
+### Eligibility
+
+You are required to obtain a company license to use Source if you are otherwise not eligible for the "Free license", including, but not limited to, if you are:
+
+- A for-profit organization with more than 3 workers;
+
+### Allowed use cases
+
+Permission is hereby granted to any legal entity eligible for the "Company license" to use the software non-commercially and commercially and modify the software for the purpose of contributing bug fixes or improvements back to Source.
+
+### Prohibited use cases
+
+Is it prohibited to copy, modify, distribute, or redistribute the software for the purpose of selling, renting, licensing, relicensing, or sublicensing own derivate of Source.
+
+### Warranty notice
+
+The software is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and non-infringement. In no event shall the author or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.
+
+### Support
+
+Support is provided on the best-we-can-do basis via GitHub Issues, granting priority support to the holders of the "Company license". Priority support implies prioritizing the issues reported by the holders of the "Company license" amongst other issues, and in no shape or form guarantees fixed first response time or issue resolution time.


### PR DESCRIPTION
Adds a draft of the dual license for the library. Largely inspired by a similar license provided by [Remotion](https://github.com/remotion-dev/remotion/blob/b13db46dd0c022c54512a71d11e7d0ff9e2354c1/LICENSE.md). 

## Todo

- [ ] List explicit conditions that the entity must fulfill in order to obtain the "Company license". I want for them to be an active sponsor of the MSW organization on GitHub as a validation criterion of such a license holder. 