### PR TITLE
Add possibility to filter oas

### DIFF
--- a/src/open-api/from-open-api.ts
+++ b/src/open-api/from-open-api.ts
@@ -36,7 +36,6 @@ export async function fromOpenApi(
   }
 
   const pathItems = Object.entries(specification.paths ?? {})
-
   for (const item of pathItems) {
     const [url, handlers] = item
     const pathItem = handlers as

--- a/test/oas/from-open-api.test.ts
+++ b/test/oas/from-open-api.test.ts
@@ -49,10 +49,10 @@ it('creates handlers based on provided filter', async () => {
     },
   })
 
-  const mapPathItem: MapOperationFunction = (url, method, operation) => {
+  const mapOperation: MapOperationFunction = (url, method, operation) => {
     return url === '/numbers' && method === 'get' ? operation : undefined
   }
-  const handlers = await fromOpenApi(openApiSpec, mapPathItem)
+  const handlers = await fromOpenApi(openApiSpec, mapOperation)
 
   expect(await inspectHandlers(handlers)).toEqual<InspectedHandler[]>([
     {

--- a/test/oas/from-open-api.test.ts
+++ b/test/oas/from-open-api.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import {
   fromOpenApi,
-  MapPathItemFunction,
+  MapOperationFunction,
 } from '../../src/open-api/from-open-api.js'
 import { createOpenApiSpec } from '../support/create-open-api-spec.js'
 import { InspectedHandler, inspectHandlers } from '../support/inspect.js'
@@ -11,6 +11,17 @@ it('creates handlers based on provided filter', async () => {
     paths: {
       '/numbers': {
         get: {
+          responses: {
+            200: {
+              content: {
+                'application/json': {
+                  example: [1, 2, 3],
+                },
+              },
+            },
+          },
+        },
+        put: {
           responses: {
             200: {
               content: {
@@ -38,8 +49,9 @@ it('creates handlers based on provided filter', async () => {
     },
   })
 
-  const mapPathItem: MapPathItemFunction = (pathItemTuple) =>
-    pathItemTuple[0] === '/numbers' ? pathItemTuple : undefined
+  const mapPathItem: MapOperationFunction = (url, method, operation) => {
+    return url === '/numbers' && method === 'get' ? operation : undefined
+  }
   const handlers = await fromOpenApi(openApiSpec, mapPathItem)
 
   expect(await inspectHandlers(handlers)).toEqual<InspectedHandler[]>([

--- a/test/oas/from-open-api.test.ts
+++ b/test/oas/from-open-api.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+import {
+  fromOpenApi,
+  MapPathItemFunction,
+} from '../../src/open-api/from-open-api.js'
+import { createOpenApiSpec } from '../support/create-open-api-spec.js'
+import { InspectedHandler, inspectHandlers } from '../support/inspect.js'
+
+it('creates handlers based on provided filter', async () => {
+  const openApiSpec = createOpenApiSpec({
+    paths: {
+      '/numbers': {
+        get: {
+          responses: {
+            200: {
+              content: {
+                'application/json': {
+                  example: [1, 2, 3],
+                },
+              },
+            },
+          },
+        },
+      },
+      '/orders': {
+        get: {
+          responses: {
+            200: {
+              content: {
+                'application/json': {
+                  example: [{ id: 1 }, { id: 2 }, { id: 3 }],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const mapPathItem: MapPathItemFunction = (pathItemTuple) =>
+    pathItemTuple[0] === '/numbers' ? pathItemTuple : undefined
+  const handlers = await fromOpenApi(openApiSpec, mapPathItem)
+
+  expect(await inspectHandlers(handlers)).toEqual<InspectedHandler[]>([
+    {
+      handler: {
+        method: 'GET',
+        path: 'http://localhost/numbers',
+      },
+      response: {
+        status: 200,
+        statusText: 'OK',
+        headers: expect.arrayContaining([['content-type', 'application/json']]),
+        body: JSON.stringify([1, 2, 3]),
+      },
+    },
+  ])
+})


### PR DESCRIPTION
Add possibility to filter open api spec spec and not mock the whole spec.

The reason for introducing this is that it's quite common case that one has open api spec with lots of endpoint definitions, but for a specific tests we want to mock just specific endpoints. Due to that, it's good to be possible to do filtering on both url and method.