### PR TITLE
fix(traffic): support `Response.error()` replays

### DIFF
--- a/src/traffic/utils/har-utils.ts
+++ b/src/traffic/utils/har-utils.ts
@@ -36,12 +36,17 @@ export function toResponseBody(
 }
 
 export function toResponse(responseEntry: Har.Response): Response {
+  if (responseEntry.status === 0) {
+    return Response.error()
+  }
+
   const body = toResponseBody(responseEntry.content)
   const response = new Response(body, {
     status: responseEntry.status,
     statusText: responseEntry.statusText,
     headers: toHeaders(responseEntry.headers),
   })
+
   return response
 }
 

--- a/test/traffic/fixtures/archives/response-error.har
+++ b/test/traffic/fixtures/archives/response-error.har
@@ -1,0 +1,142 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [],
+    "entries": [
+      {
+        "_initiator": {
+          "type": "script",
+          "stack": {
+            "callFrames": [
+              {
+                "functionName": "eval",
+                "scriptId": "13",
+                "url": "",
+                "lineNumber": 3,
+                "columnNumber": 39
+              },
+              {
+                "functionName": "eval",
+                "scriptId": "13",
+                "url": "",
+                "lineNumber": 1,
+                "columnNumber": 56
+              },
+              {
+                "functionName": "evaluate",
+                "scriptId": "6",
+                "url": "",
+                "lineNumber": 340,
+                "columnNumber": 15
+              },
+              {
+                "functionName": "",
+                "scriptId": "12",
+                "url": "",
+                "lineNumber": 0,
+                "columnNumber": 43
+              }
+            ]
+          }
+        },
+        "_priority": "High",
+        "_resourceType": "fetch",
+        "cache": {},
+        "connection": "29",
+        "request": {
+          "method": "GET",
+          "url": "http://127.0.0.1:61959/resource",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Host",
+              "value": "127.0.0.1:61959"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"93\", \" Not;A Brand\";v=\"99\""
+            },
+            {
+              "name": "sec-ch-ua-mobile",
+              "value": "?0"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4576.0 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua-platform",
+              "value": "\"macOS\""
+            },
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Origin",
+              "value": "null"
+            },
+            {
+              "name": "Sec-Fetch-Site",
+              "value": "cross-site"
+            },
+            {
+              "name": "Sec-Fetch-Mode",
+              "value": "cors"
+            },
+            {
+              "name": "Sec-Fetch-Dest",
+              "value": "empty"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.9"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 473,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 0,
+          "statusText": "",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "cookies": [],
+          "content": {},
+          "redirectURL": "",
+          "headersSize": 0,
+          "bodySize": -1,
+          "_transferSize": 0,
+          "_error": null
+        },
+        "serverIPAddress": "127.0.0.1",
+        "startedDateTime": "2021-08-12T14:32:07.024Z",
+        "time": 7.389999998976128,
+        "timings": {
+          "blocked": 0.6869999996825354,
+          "dns": 0.0050000000000000044,
+          "ssl": -1,
+          "connect": 0.19199999999999998,
+          "send": 0.10300000000000004,
+          "wait": 6.10100000073819,
+          "receive": 0.30199999855540227,
+          "_blocked_queueing": 0.5309999996825354
+        }
+      }
+    ]
+  }
+}

--- a/test/traffic/response-error.test.ts
+++ b/test/traffic/response-error.test.ts
@@ -1,0 +1,22 @@
+import { fromTraffic } from '../../src/traffic/from-traffic'
+import { InspectedHandler, inspectHandlers } from '../support/inspect'
+import { normalizeLocalhost, readArchive } from './utils'
+
+it('replays an error response (status code 0)', async () => {
+  const har = readArchive('test/traffic/fixtures/archives/response-error.har')
+  const handlers = fromTraffic(har, normalizeLocalhost)
+  expect(await inspectHandlers(handlers)).toEqual<InspectedHandler[]>([
+    {
+      handler: {
+        method: 'GET',
+        path: 'http://localhost/resource',
+      },
+      response: {
+        status: 0,
+        statusText: '',
+        headers: [],
+        body: '',
+      },
+    },
+  ])
+})


### PR DESCRIPTION
- Fixes #53 