### PR TITLE
fix: return `HttpHandler` from `fromTraffic` and `fromOpenApi` functions

### DIFF
--- a/src/open-api/from-open-api.ts
+++ b/src/open-api/from-open-api.ts
@@ -1,4 +1,4 @@
-import { RequestHandler, HttpHandler, http } from 'msw'
+import { HttpHandler, http } from 'msw'
 import type { OpenAPIV3, OpenAPIV2, OpenAPI } from 'openapi-types'
 import { parse } from 'yaml'
 import { normalizeSwaggerUrl } from './utils/normalize-swagger-url.js'
@@ -21,11 +21,11 @@ const supportedHttpMethods = Object.keys(
  */
 export async function fromOpenApi(
   document: string | OpenAPI.Document | OpenAPIV3.Document | OpenAPIV2.Document,
-): Promise<Array<RequestHandler>> {
+): Promise<Array<HttpHandler>> {
   const parsedDocument =
     typeof document === 'string' ? parse(document) : document
   const specification = await dereference(parsedDocument)
-  const requestHandlers: Array<RequestHandler> = []
+  const requestHandlers: Array<HttpHandler> = []
 
   if (typeof specification.paths === 'undefined') {
     return []

--- a/src/traffic/from-traffic.ts
+++ b/src/traffic/from-traffic.ts
@@ -1,6 +1,6 @@
 import { invariant } from 'outvariant'
 import type Har from 'har-format'
-import { RequestHandler, HttpHandler, cleanUrl, delay } from 'msw'
+import { HttpHandler, cleanUrl, delay } from 'msw'
 import { matchesQueryParameters, toResponse } from './utils/har-utils.js'
 
 export type MapEntryFunction = (entry: Har.Entry) => Har.Entry | undefined
@@ -16,7 +16,7 @@ export type MapEntryFunction = (entry: Har.Entry) => Har.Entry | undefined
 export function fromTraffic(
   archive: Har.Har,
   mapEntry?: MapEntryFunction,
-): Array<RequestHandler> {
+): Array<HttpHandler> {
   invariant(
     archive,
     'Failed to generate request handlers from traffic: expected an HAR object but got %s.',
@@ -29,7 +29,7 @@ export function fromTraffic(
   )
 
   const requestIds = new Set<string>()
-  const handlers: Array<RequestHandler> = []
+  const handlers: Array<HttpHandler> = []
 
   // Loop over the HAR entries from right to left.
   for (let i = archive.log.entries.length - 1; i >= 0; i--) {

--- a/test/oas/petstore.test.ts
+++ b/test/oas/petstore.test.ts
@@ -1,14 +1,13 @@
 // @vitest-environment happy-dom
-import { RequestHandler } from 'msw'
+import { HttpHandler } from 'msw'
 import { fromOpenApi } from '../../src/open-api/from-open-api.js'
 import { withHandlers } from '../../test/support/with-handlers.js'
+import petstoreSpecification from './fixtures/petstore.json' assert { type: 'json' }
 
-const petstoreSpecification = require('./fixtures/petstore.json')
-
-let handlers: RequestHandler[]
+let handlers: Array<HttpHandler>
 
 beforeAll(async () => {
-  handlers = await fromOpenApi(petstoreSpecification)
+  handlers = await fromOpenApi(petstoreSpecification as any)
 })
 
 const entities = {

--- a/test/support/with-handlers.ts
+++ b/test/support/with-handlers.ts
@@ -1,4 +1,4 @@
-import { RequestHandler } from 'msw'
+import type { RequestHandler } from 'msw'
 import { setupServer } from 'msw/node'
 
 /**

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,6 +7,7 @@
   ],
   "compilerOptions": {
     "composite": true,
+    "module": "preserve",
     "types": ["vitest/globals"],
     "lib": ["dom", "DOM.Iterable"]
   },


### PR DESCRIPTION
- Related to https://github.com/mswjs/http-middleware/issues/48